### PR TITLE
chore(docs): write mint documentation

### DIFF
--- a/docs/.markdownlint.json
+++ b/docs/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "MD013": false,
+  "MD024": false
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,78 @@
+# Architecture
+
+This page explains how Mint is organized and how the build process works.
+
+## Project layout
+
+The main folders are:
+
+- `src/` — extension source code and `manifest.json`
+- `assets/` — files that should be embedded in the extension
+- `dist/` — generated extension bundles
+- `scripts/` — build and project tooling
+- `docs/` — user-facing documentation
+
+Important files:
+
+- `package.json` — project metadata and scripts
+- `scripts/build.js` — bundler and validator
+- `scripts/init.js` — project scaffold helper
+- `scripts/asset.js` — asset manager
+
+## Source code flow
+
+Mint collects all JavaScript files in `src/`, bundles them, and produces a single file that TurboWarp can load.
+
+### Step 1: Read source files
+
+The build script scans `src/` for `.js` files and creates an entry bundle.
+
+### Step 2: Bundle with `esbuild`
+
+Mint uses `esbuild` to bundle code into an IIFE (`format: "iife"`).
+This means the final output is one self-executing JavaScript file.
+
+### Step 3: Clean up registration code
+
+Some extension source can contain Scratch registration helpers.
+The build script removes those helper calls before the final output is written.
+
+### Step 4: Embed assets and manifest values
+
+Mint turns local assets from `assets/` into base64 data URIs.
+It also exposes manifest values through a small runtime object.
+
+The final output includes two helper objects:
+
+- `__mintAssets__` — holds encoded assets
+- `__mintManifest__` — holds manifest values
+
+Those helpers are accessed through the `mint` object in generated code.
+
+## Runtime `mint` helpers
+
+Mint provides two runtime getters:
+
+- `mint.asset.get(name)`
+- `mint.manifest.get(key)`
+
+These functions return values only if the requested key or asset exists. If the requested value is missing, they return an empty string.
+
+## Validation during build
+
+Before writing the bundle, Mint checks that:
+
+- every static `mint.asset.get("...")` call in `src/` refers to an actual file in `assets/`
+- every static `mint.manifest.get("...")` call refers to a real key in `src/manifest.json`
+
+If either check fails, the build stops with an error.
+
+## Why Mint uses base64 assets
+
+Bundling assets as data URIs means the final extension file is self-contained.
+That makes it easier to distribute and load in TurboWarp without separate asset hosting.
+
+## Output file
+
+The final file is written to `dist/<extension-id>.js`.
+The `<extension-id>` value comes from `src/manifest.json`.

--- a/docs/assets.md
+++ b/docs/assets.md
@@ -1,0 +1,84 @@
+# Assets
+
+Mint supports bundling static files from the `assets/` directory into your extension.
+
+## Why use `assets/`
+
+The `assets/` folder is where you put images, audio, text files, and other files your extension needs at runtime.
+
+During the build, Mint reads these files and converts them into base64 data URIs.
+That means your final extension bundle contains everything it needs in one file.
+
+## Adding assets
+
+Use the asset manager:
+
+```bash
+pnpm asset:add -- ./local/logo.svg logo.svg
+```
+
+Arguments:
+
+- source file path
+- optional asset name inside `assets/`
+
+If you do not specify a destination name, Mint uses the source file name.
+
+## Listing assets
+
+To see what is currently available:
+
+```bash
+pnpm asset:list
+```
+
+This command prints every file under `assets/` with its size.
+
+## Removing assets
+
+To delete an asset:
+
+```bash
+pnpm asset:remove -- logo.svg
+```
+
+This removes the file from `assets/` and it will no longer be bundled.
+
+## Asset usage in code
+
+In your source files, use `mint.asset.get("path/to/file")` to read an embedded asset.
+
+Example:
+
+```js
+const iconData = mint.asset.get("icon.png");
+const imageUrl = iconData ? `url(${iconData})` : "";
+```
+
+## Rules and limitations
+
+- Asset names are normalized and cannot escape the `assets/` folder.
+- The path you use in `mint.asset.get(...)` must match the path under `assets/` exactly.
+- Unsupported paths or missing files cause a build error if referenced statically.
+
+## What file types work?
+
+Mint recognizes common MIME types such as:
+
+- `.svg`
+- `.png`
+- `.jpg`, `.jpeg`
+- `.gif`
+- `.webp`
+- `.ico`
+- `.mp3`
+- `.wav`
+- `.ogg`
+- `.mp4`
+- `.webm`
+- `.json`
+- `.txt`
+- `.css`
+- `.html`
+
+Other extensions are bundled as `application/octet-stream`.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -9,8 +9,8 @@ The package scripts in `package.json` are the easiest way to use Mint.
 - `pnpm build`
   - Runs `node scripts/build.js`
   - Bundles your extension from `src/` into `dist/`
-- `pnpm init`
-  - Runs `node scripts/init.js`
+- `pnpm run init`
+  - Runs `node scripts/init.js` (defined in package.json)
   - Prompts for metadata and creates a minimal extension entry point
 - `pnpm asset:list`
   - Runs `node scripts/asset.js list`
@@ -68,7 +68,7 @@ node scripts/asset.js remove icon.png
 
 A typical Mint workflow looks like this:
 
-1. `pnpm init` to set project metadata and create a starter extension
+1. `pnpm run init` to set project metadata and create a starter extension
 2. `pnpm asset:add` to add files needed by the extension
 3. `pnpm build` to generate `dist/` output
 4. `pnpm lint` and `pnpm format` to keep code clean

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,80 @@
+# Commands
+
+Mint exposes a small set of scripts through `pnpm` and Node.
+
+## `pnpm` commands
+
+The package scripts in `package.json` are the easiest way to use Mint.
+
+- `pnpm build`
+  - Runs `node scripts/build.js`
+  - Bundles your extension from `src/` into `dist/`
+- `pnpm init`
+  - Runs `node scripts/init.js`
+  - Prompts for metadata and creates a minimal extension entry point
+- `pnpm asset:list`
+  - Runs `node scripts/asset.js list`
+  - Shows all files stored under `assets/`
+- `pnpm asset:add`
+  - Runs `node scripts/asset.js add`
+  - Copies a local file into `assets/`
+- `pnpm asset:remove`
+  - Runs `node scripts/asset.js remove`
+  - Deletes an asset from `assets/`
+- `pnpm lint`
+  - Runs ESLint across the repository
+- `pnpm format`
+  - Runs Prettier across the repository
+- `pnpm test`
+  - Placeholder test command
+
+## Node scripts
+
+You can also run the scripts directly with Node.
+
+### `node scripts/build.js`
+
+Builds a single distributable extension file from all JavaScript files in `src/`.
+
+Example:
+
+```bash
+node scripts/build.js
+```
+
+### `node scripts/init.js`
+
+Initializes the project and updates metadata in `src/manifest.json` and `package.json`.
+
+Example:
+
+```bash
+node scripts/init.js
+```
+
+### `node scripts/asset.js`
+
+Manages files inside `assets/`.
+
+Example:
+
+```bash
+node scripts/asset.js list
+node scripts/asset.js add ./local/image.png image.png
+node scripts/asset.js remove icon.png
+```
+
+## Command flow
+
+A typical Mint workflow looks like this:
+
+1. `pnpm init` to set project metadata and create a starter extension
+2. `pnpm asset:add` to add files needed by the extension
+3. `pnpm build` to generate `dist/` output
+4. `pnpm lint` and `pnpm format` to keep code clean
+
+## Notes for beginners
+
+- `pnpm` is a package manager similar to npm or Yarn.
+- The `--` separator is required for `pnpm` when passing extra arguments to a script.
+- Example: `pnpm asset:add -- ./local/image.png image.png`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ This document helps you start using Mint quickly.
 
 ## What you need
 
-- Node.js 20+ or 22+ or 24+
+- Node.js 20.19.0+, 22.13.0+, or 24+ (see package.json "engines.node")
 - `pnpm` (Mint uses `pnpm@10.32.1` via Corepack)
 - A terminal with access to the project folder
 
@@ -25,7 +25,9 @@ Mint includes an initialization script that updates metadata and creates a minim
 Run:
 
 ```bash
-pnpm init
+pnpm run init
+# or
+node scripts/init.js
 ```
 
 The script asks for:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,86 @@
+# Getting Started
+
+This document helps you start using Mint quickly.
+
+## What you need
+
+- Node.js 20+ or 22+ or 24+
+- `pnpm` (Mint uses `pnpm@10.32.1` via Corepack)
+- A terminal with access to the project folder
+
+## Install dependencies
+
+From the project root:
+
+```bash
+pnpm install
+```
+
+This installs the packages Mint uses to build and validate your extension.
+
+## Create a new extension
+
+Mint includes an initialization script that updates metadata and creates a minimal `src/` entry point.
+
+Run:
+
+```bash
+pnpm init
+```
+
+The script asks for:
+
+- extension name
+- extension ID
+- description
+- author
+- author link
+- license
+- npm package name
+- repository URL
+- homepage URL
+- bugs URL
+
+After you finish, Mint writes or updates:
+
+- `src/manifest.json`
+- `package.json`
+- `src/index.js`
+
+It also removes project contributor files such as `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, and `SECURITY.md` when they are not needed for a generated extension.
+
+## Build the extension
+
+Use the build tool to generate a distributable extension file:
+
+```bash
+pnpm build
+```
+
+The build output is written to:
+
+- `dist/<extension-id>.js`
+
+This file is ready for TurboWarp or Scratch-compatible extension loading.
+
+## Manage assets
+
+Mint can bundle files from `assets/` into your extension.
+
+Common commands:
+
+```bash
+pnpm asset:list
+pnpm asset:add -- ./local/image.png image.png
+pnpm asset:remove -- image.png
+```
+
+Assets are embedded as base64 data URIs during the build.
+
+## Learn more
+
+If you want to understand the project layout or how Mint builds extensions, continue to:
+
+- [Architecture](./architecture.md)
+- [Commands](./commands.md)
+- [Scripts Reference](./scripts.md)

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -39,8 +39,7 @@ If your code requests a missing key, the build fails and reports the missing ref
 
 ## Keeping versions in sync
 
-`build.js` reads the version from `package.json` and updates `src/manifest.json` before bundling.
-That means the manifest version in your final extension always matches the package version.
+`build.js` reads the version from `package.json` and uses it when generating the bundle. It does not overwrite `src/manifest.json` on disk; the adjustment is applied in-memory during the build, so your source manifest file remains unchanged.
 
 ## Best practices
 

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -1,0 +1,50 @@
+# Manifest
+
+Mint uses `src/manifest.json` for extension metadata.
+
+## What `manifest.json` contains
+
+The file stores values that describe your extension, such as:
+
+- `name`
+- `id`
+- `description`
+- `author`
+- `authorLink`
+- `license`
+- `version`
+
+These values are included in the generated extension bundle and can be read at runtime.
+
+## Why manifest values matter
+
+The build script reads `src/manifest.json` and embeds its values into the final output.
+This keeps your extension metadata consistent with your source and package files.
+
+## Using manifest values in code
+
+In your source files, use `mint.manifest.get("key")` to read values.
+
+Example:
+
+```js
+const extensionName = mint.manifest.get("name");
+const authorLink = mint.manifest.get("authorLink");
+```
+
+## Validation
+
+During build, Mint checks that every static `mint.manifest.get("...")` call refers to a real key in `src/manifest.json`.
+If your code requests a missing key, the build fails and reports the missing reference.
+
+## Keeping versions in sync
+
+`build.js` reads the version from `package.json` and updates `src/manifest.json` before bundling.
+That means the manifest version in your final extension always matches the package version.
+
+## Best practices
+
+- Keep `id` short and unique.
+- Use plain text for `name`, `description`, and `author`.
+- Use `authorLink` for your GitHub profile or project page.
+- If your extension references manifest values at runtime, be sure to use exact key names.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -19,7 +19,7 @@ These scripts are designed for the project itself and are called from `package.j
 The project defines these commands in `package.json`:
 
 - `pnpm build` - run `node scripts/build.js`
-- `pnpm init` - run `node scripts/init.js`
+- `pnpm run init` - run `node scripts/init.js`
 - `pnpm asset:list` - run `node scripts/asset.js list`
 - `pnpm asset:add` - run `node scripts/asset.js add`
 - `pnpm asset:remove` - run `node scripts/asset.js remove`

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -1,0 +1,167 @@
+# Scripts Reference
+
+This document explains the Node scripts in `scripts/` and how they are used in the Mint project.
+
+Mint uses small, focused scripts instead of a large build system. Each script is a command-line tool that runs with Node and keeps your workflow simple.
+
+## What lives in `scripts/`
+
+The `scripts/` folder contains three main utilities:
+
+- `build.js` - bundle your extension and generate a distributable file in `dist/`
+- `asset.js` - manage runtime assets stored under `assets/`
+- `init.js` - scaffold a new TurboWarp extension and update metadata files
+
+These scripts are designed for the project itself and are called from `package.json` script entries.
+
+## Available `pnpm` commands
+
+The project defines these commands in `package.json`:
+
+- `pnpm build` - run `node scripts/build.js`
+- `pnpm init` - run `node scripts/init.js`
+- `pnpm asset:list` - run `node scripts/asset.js list`
+- `pnpm asset:add` - run `node scripts/asset.js add`
+- `pnpm asset:remove` - run `node scripts/asset.js remove`
+
+There are also standard housekeeping scripts:
+
+- `pnpm lint` - run ESLint
+- `pnpm format` - run Prettier
+- `pnpm test` - placeholder test command
+
+## `build.js`
+
+The `build.js` script is the core bundler for Mint.
+
+### Purpose
+
+- bundle all JavaScript source files from `src/`
+- inline assets from `assets/` as base64 data URIs
+- validate `mint.asset.get(...)` and `mint.manifest.get(...)` references
+- generate a single extension file in `dist/`
+
+### How it works
+
+1. It reads `src/manifest.json` and the package version from `package.json`.
+2. It scans `src/` for JavaScript files and bundles them with `esbuild`.
+3. It converts the bundled output into a clean form and removes any Scratch extension registration helper code used during development.
+4. It collects all files under `assets/`, encodes them as base64, and embeds them into a runtime object.
+5. It validates that every static `mint.asset.get("...")` call refers to a real asset file.
+6. It validates that every static `mint.manifest.get("...")` call refers to an existing key in `manifest.json`.
+7. It writes a final extension file in `dist/`, wrapped in an IIFE that registers the extension with Scratch.
+
+### Key study points
+
+- `esbuild` is used with `format: "iife"`, which produces a self-invoking function.
+- `@babel/parser` parses source code into an AST so the script can inspect `mint.asset.get` and `mint.manifest.get` calls.
+- `magic-string` is used to remove unneeded registration statements from generated code.
+- Asset and manifest data are embedded using `JSON.stringify` into `Object.create(null)` objects.
+
+### Output
+
+The bundled extension is written to `dist/<id>.js`, where `<id>` comes from `src/manifest.json`.
+
+## `asset.js`
+
+The `asset.js` script helps you manage files inside the `assets/` folder.
+
+### Purpose
+
+- list all asset files currently present
+- add a new asset file to the project
+- remove an existing asset file
+
+### Supported subcommands
+
+- `node scripts/asset.js list`
+- `node scripts/asset.js add <source-file> [dest-name]`
+- `node scripts/asset.js remove <asset-name>`
+
+### What each subcommand does
+
+#### `list`
+
+- Recursively scans the `assets/` directory.
+- Prints every file path and its size.
+- Helps you see which assets are included in the build.
+
+#### `add`
+
+- Copies a file from the local filesystem into `assets/`.
+- The first argument is the path to the source file.
+- The optional second argument is the asset name inside `assets/`.
+- If the destination file already exists, it overwrites it and warns you.
+
+Example:
+
+```bash
+pnpm asset:add -- ./local/image.png image.png
+```
+
+#### `remove`
+
+- Deletes an asset from `assets/`.
+- The argument is the path to the asset relative to `assets/`.
+
+Example:
+
+```bash
+pnpm asset:remove -- icon.png
+```
+
+### Important behavior
+
+- Destination names are normalized and cannot escape the `assets/` folder.
+- The script checks that the source path exists and is a file.
+- Invalid or missing arguments produce a friendly usage hint.
+
+## `init.js`
+
+The `init.js` script helps bootstrap a new extension project.
+
+### Purpose
+
+- remove contributor files that are not part of a generated extension
+- prompt the user for extension metadata
+- update `src/manifest.json` and `package.json`
+- replace the `src/` sample code with a minimal extension entry point
+- run `pnpm install`
+
+### What it prompts for
+
+- Extension name
+- Extension ID
+- Description
+- Author
+- Author link
+- License
+- npm package name
+- Repository URL
+- Homepage URL
+- Bugs URL
+
+The script preserves existing values where possible and uses them as defaults.
+
+### How it updates the project
+
+- removes `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, and `SECURITY.md` if present
+- writes `src/manifest.json` with the answered metadata
+- writes `package.json` entries and script commands
+- writes a minimal `src/index.js` with a Scratch extension class and registration call
+
+### Developer notes
+
+- `init.js` requires an interactive terminal (`TTY`).
+- It uses Node's `readline` module to ask questions.
+- It normalizes author links so GitHub usernames become full URLs.
+
+## Why this folder exists
+
+The `scripts/` folder is the build and project plumbing for Mint.
+
+- `build.js` turns the extension source into the final file TurboWarp consumes.
+- `asset.js` manages files that must be bundled as runtime assets.
+- `init.js` makes it easy to start a new extension project without manual setup.
+
+If you are learning how Mint works, start by reading `scripts/build.js` first, then `scripts/asset.js`, and finally `scripts/init.js`.

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -1,6 +1,6 @@
 # Mint Documentation
 
-User-level documentation for Mint is not yet available.
+This serves as the user-level documentation for Mint.
 
 ---
 
@@ -8,8 +8,11 @@ User-level documentation for Mint is not yet available.
 
 The table of contents, in no particular order:
 
-> [!IMPORTANT]
->
-> User-level documentation for Mint is not yet available.
+- [Getting Started](./getting-started.md)
+- [Commands](./commands.md)
+- [Architecture](./architecture.md)
+- [Assets](./assets.md)
+- [Manifest](./manifest.md)
+- [Scripts Reference](./scripts.md)
 
 > For an overview of the project, see its [README](./../README.md).


### PR DESCRIPTION
# `📃` Overview

This pull request adds comprehensive user-facing documentation for the Mint project. It introduces new guides covering getting started, architecture, commands, asset management, manifest usage, and detailed script references. The documentation is organized with a table of contents and disables some markdown linting rules for clarity.

**New documentation and guides:**

* Added a table of contents and updated the main documentation entry point in `docs/toc.md` to reference all new user guides.
* Added a "Getting Started" guide with installation, initialization, building, and asset management instructions in `docs/getting-started.md`.
* Added an "Architecture" overview in `docs/architecture.md` explaining project structure, build flow, and runtime helpers.
* Added a "Commands" reference in `docs/commands.md` detailing available `pnpm` and Node scripts and typical workflows.
* Added an "Assets" guide in `docs/assets.md` covering asset bundling, management, usage in code, and supported file types.
* Added a "Manifest" guide in `docs/manifest.md` explaining metadata usage, validation, and best practices.
* Added a "Scripts Reference" in `docs/scripts.md` describing the purpose and behavior of each build and asset management script.

**Documentation infrastructure:**

* Disabled markdownlint rules `MD013` (line length) and `MD024` (heading duplication) in `docs/.markdownlint.json` to improve formatting flexibility.

## `ℹ️` Extra Details

- _Closes issue:_ #14.
- _Pull request type:_ Documentation.

## `☑️` Checklist

- [X] I made sure this Pull request generates no more errors or Problems in VS Code _(or other editors)_.
- [X] I double-checked for typos or small errors.
- [X] I made sure this code matches this repository's style.
- [X] I linked a corresponding Issue.
