### PR TITLE
fix(build): build script over-writes extension version with package.json

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -39,7 +39,7 @@ If your code requests a missing key, the build fails and reports the missing ref
 
 ## Keeping versions in sync
 
-`build.js` reads the version from `package.json` and uses it when generating the bundle. It does not overwrite `src/manifest.json` on disk; the adjustment is applied in-memory during the build, so your source manifest file remains unchanged.
+Mint respects the version declared in `src/manifest.json`. If a version is present there, the build uses it; otherwise the build falls back to the version in `package.json`. The build does not modify `src/manifest.json` on disk — any adjustment is applied in-memory during bundle generation.
 
 ## Best practices
 

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -39,7 +39,7 @@ If your code requests a missing key, the build fails and reports the missing ref
 
 ## Keeping versions in sync
 
-Mint respects the version declared in `src/manifest.json`. If a version is present there, the build uses it; otherwise the build falls back to the version in `package.json`. The build does not modify `src/manifest.json` on disk — any adjustment is applied in-memory during bundle generation.
+Mint respects the version declared in `src/manifest.json`. If a version is present there, the build uses it; otherwise the build falls back to the version in `package.json`. If the two files differ, Mint will prefer `src/manifest.json` (applied in-memory during bundle generation) but will also emit a version-mismatch warning in the build logs to alert you; reconcile the versions in `src/manifest.json` and `package.json` to silence the warning. The build does not modify `src/manifest.json` on disk — any adjustment is applied in-memory during bundle generation.
 
 ## Best practices
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kanebuilt/mint-tooling",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Develop TurboWarp extensions using bundling",
   "homepage": "https://github.com/kanebuilt/mint-tooling",
   "bugs": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -17,7 +17,7 @@ const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
 
 // Logging helpers to match other scripts (init.js)
 const _info = (message) => console.log(`\x1b[36mℹ\x1b[0m ${message}`);
-const warn = (message) => console.log(`\x1b[33m⚠\x1b[0m ${message}`);
+const warn = (message) => console.warn(`\x1b[33m⚠\x1b[0m ${message}`);
 const _fail = (message) => console.error(`\x1b[31m✗\x1b[0m ${message}`);
 
 const { name, id, description, author, authorLink, license } = manifest;
@@ -305,7 +305,7 @@ const buildBundle = async () => {
   }
   if (missingRefs.length > 0) {
     for (const { asset, file } of missingRefs) {
-      console.error(`\x1b[31m✗\x1b[0m Missing asset "${asset}" referenced in ${file}`);
+      _fail(`Missing asset "${asset}" referenced in ${file}`);
     }
     throw new Error(`Build failed: ${missingRefs.length} missing asset reference(s)`);
   }
@@ -323,7 +323,7 @@ const buildBundle = async () => {
   }
   if (missingManifestRefs.length > 0) {
     for (const { key, file } of missingManifestRefs) {
-      console.error(`\x1b[31m✗\x1b[0m Missing manifest key "${key}" referenced in ${file}`);
+      _fail(`Missing manifest key "${key}" referenced in ${file}`);
     }
     throw new Error(
       `Build failed: ${missingManifestRefs.length} missing manifest key reference(s)`
@@ -343,7 +343,7 @@ const buildBundle = async () => {
   const headerLines = [
     `// Name: ${name}`,
     `// ID: ${id}`,
-    `// Version: ${packageVersion}`,
+    `// Version: ${manifest.version}`,
     `// Description: ${description}`,
     `// By: ${author} <${authorLink}>`,
     `// License: ${license}`,
@@ -376,10 +376,10 @@ ${codeWithMint
   fs.writeFileSync(outputPath, output, "utf8");
 
   const assetSuffix = assetCount > 0 ? ` with ${assetCount} asset(s)` : "";
-  console.log(`✓ Bundled ${name} successfully${assetSuffix}!`);
+  _info(`✓ Bundled ${name} successfully${assetSuffix}!`);
 };
 
 buildBundle().catch((error) => {
-  console.error(error);
+  _fail(error && error.stack ? error.stack : String(error));
   process.exit(1);
 });

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -14,9 +14,26 @@ const packagePath = path.join(rootDir, "package.json");
 
 const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
 const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+
+// Logging helpers to match other scripts (init.js)
+const _info = (message) => console.log(`\x1b[36mℹ\x1b[0m ${message}`);
+const warn = (message) => console.log(`\x1b[33m⚠\x1b[0m ${message}`);
+const _fail = (message) => console.error(`\x1b[31m✗\x1b[0m ${message}`);
+
 const { name, id, description, author, authorLink, license } = manifest;
 const packageVersion = packageJson.version;
-manifest.version = packageVersion;
+
+// If src/manifest.json has an explicit version that differs from package.json, warn but continue.
+// If no version is present in src/manifest.json, fall back to package.json's version.
+if (Object.prototype.hasOwnProperty.call(manifest, "version")) {
+  if (String(manifest.version) !== String(packageVersion)) {
+    warn(
+      `Version mismatch: src/manifest.json has "${manifest.version}", but package.json has "${packageVersion}". Using src/manifest.json version.`
+    );
+  }
+} else {
+  manifest.version = packageVersion;
+}
 
 let gitRemote = null;
 try {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,5 +5,5 @@
   "author": "KaneBuilt",
   "authorLink": "https://github.com/kanebuilt",
   "license": "LGPL-2.0-only",
-  "version": "0.5.0"
+  "version": "0.5.1"
 }


### PR DESCRIPTION
# `📃` Overview

This pull request updates the version to `0.5.1` and improves how the build process handles version synchronization between `src/manifest.json` and `package.json`. It also enhances logging in the build script for better developer feedback.

Versioning and manifest handling:

* Updated the version in both `package.json` and `src/manifest.json` from `0.5.0` to `0.5.1` to keep them in sync. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-6bc2c0b5164076a1b57b067398be19a40d2b8efa3428b03504562ea88593866cL8-R8)
* Changed the build process to prioritize the version in `src/manifest.json` if present; if not, it falls back to `package.json`. If the versions differ, the build logs a warning but proceeds using the manifest version. [[1]](diffhunk://#diff-a992dd64a8c626fedc95d613f43602b91f6dc6339893afaf405dc05fa13c9ceaR17-R36) [[2]](diffhunk://#diff-a01e0fd52f82ea905ba8894a47d50a60d8289ebd2ba670edb0741f75c4c9ac35L42-R42)

Developer experience:

* Added color-coded logging helpers (`_info`, `warn`, `_fail`) to `scripts/build.js` for clearer build output and warnings.

## `ℹ️` Extra Details

- _Closes issue:_ Closes #16.
- _Pull request type:_ Bug fix.

## `☑️` Checklist

- [X] I made sure this Pull request generates no more errors or Problems in VS Code _(or other editors)_.
- [X] I double-checked for typos or small errors.
- [X] I made sure this code matches this repository's style.
- [X] I linked a corresponding Issue.
